### PR TITLE
Update AKS context setup to use absolute path for kubeconfig

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Set AKS Context
         run: |
           echo "${{ secrets.KUBECONFIG_SECRET }}" > kubeconfig
-          export KUBECONFIG=kubeconfig
+          export KUBECONFIG=$(pwd)/kubeconfig
+          kubectl config view # Validate the kubeconfig file
 
       - name: Set image version in deployment
         run: |


### PR DESCRIPTION
Change the kubeconfig environment variable to use an absolute path for better reliability in the AKS context setup.